### PR TITLE
Correct argument style in random networks error messages

### DIFF
--- a/random_networks/compute_network_stats.py
+++ b/random_networks/compute_network_stats.py
@@ -32,9 +32,9 @@ def getArgs():
 
 	if args.bibcGroups == "node_types":
 		if args.nodeMap is None:
-			raise Exception("If using node_types, must supply a node map with --nodeMap")
+			raise Exception("If using node_types, must supply a node map with --node-map")
 		if args.nodeGroups is None:
-			raise Exception("If using node_types, must supply node groups with --nodeGroups")
+			raise Exception("If using node_types, must supply node groups with --node-groups")
 
 	if args.nodeMap is not None:
 		args.nodeMap = Path(args.nodeMap)


### PR DESCRIPTION
Previously, the argument style for these scripts were changed from camel case to dash-separated. This change updates some error messages to match this new style.